### PR TITLE
Updated samples to use C# classes for deserialized JSON.

### DIFF
--- a/BreakSentence.cs
+++ b/BreakSentence.cs
@@ -60,7 +60,7 @@ namespace BreakSentenceSample
             // Output languages are defined in the route.
             // For a complete list of options, see API reference.
             // https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-break-sentence
-            string subscriptionKey = "ae3194e69b09498ea39245a8e399e6c0";
+            string subscriptionKey = "YOUR_TRANSLATOR_TEXT_KEY_GOES_HERE";
             string host = "https://api.cognitive.microsofttranslator.com";
             string route = "/breaksentence?api-version=3.0";
             string breakSentenceText = @"How are you doing today? The weather is pretty pleasant. Have you been to the movies lately?";

--- a/BreakSentence.cs
+++ b/BreakSentence.cs
@@ -29,7 +29,7 @@ namespace BreakSentenceSample
         // Async call to the Translator Text API
         static public async Task TransliterateTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            System.Object[] body = new System.Object[] { new { Text = inputText } };
+            object[] body = new object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())

--- a/BreakSentence.cs
+++ b/BreakSentence.cs
@@ -1,45 +1,70 @@
+// This sample uses C# 7.1 or later for async/await.
+
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+// Install Newtonsoft.Json with NuGet
 using Newtonsoft.Json;
 
-namespace BreakSentence
+namespace BreakSentenceSample
 {
+    /// <summary>
+    /// The C# classes that represents the JSON returned by the Translator Text API.
+    /// </summary>
+    public class BreakSentenceResult
+    {
+        public int[] SentLen { get; set; }
+        public DetectedLanguage DetectedLanguage { get; set; }
+    }
+
+    public class DetectedLanguage
+    {
+        public string Language { get; set; }
+        public float Score { get; set; }
+    }
+
     class Program
     {
-        static void BreakSentence()
+        // Async call to the Translator Text API
+        static public async Task TransliterateTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            string host = "https://api.cognitive.microsofttranslator.com";
-            string route = "/breaksentence?api-version=3.0&language=en";
-            string subscriptionKey = "YOUR_SUBSCRIPTION_KEY";
-
-            System.Object[] body = new System.Object[] { new { Text = @"How are you? I am fine. What did you do today?" } };
+            System.Object[] body = new System.Object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())
             using (var request = new HttpRequestMessage())
             {
-                // Set the method to POST
+                // Build the request.
                 request.Method = HttpMethod.Post;
-                // Construct the full URI
                 request.RequestUri = new Uri(host + route);
-                // Add the serialized JSON object to your request
                 request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                // Add the authorization header
                 request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-                // Send request, get response
-                var response = client.SendAsync(request).Result;
-                var jsonResponse = response.Content.ReadAsStringAsync().Result;
-                // Print the response
-                Console.WriteLine(jsonResponse);
-                Console.WriteLine("Press any key to continue.");
+
+                // Send the request and get response.
+                HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
+                // Read response as a string.
+                string result = await response.Content.ReadAsStringAsync();
+                BreakSentenceResult[] deserializedOutput = JsonConvert.DeserializeObject<BreakSentenceResult[]>(result);
+                foreach (BreakSentenceResult o in deserializedOutput)
+                {
+                    Console.WriteLine("The detected language is '{0}'. Confidence is: {1}.", o.DetectedLanguage.Language, o.DetectedLanguage.Score);
+                    Console.WriteLine("The first sentence length is: {0}", o.SentLen[0]);
+                }
             }
         }
-        static void Main(string[] args)
-        {
-            BreakSentence();
-            Console.ReadLine();
 
+        static async Task Main(string[] args)
+        {
+            // This is our main function.
+            // Output languages are defined in the route.
+            // For a complete list of options, see API reference.
+            // https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-break-sentence
+            string subscriptionKey = "ae3194e69b09498ea39245a8e399e6c0";
+            string host = "https://api.cognitive.microsofttranslator.com";
+            string route = "/breaksentence?api-version=3.0";
+            string breakSentenceText = @"How are you doing today? The weather is pretty pleasant. Have you been to the movies lately?";
+            await TransliterateTextRequest(subscriptionKey, host, route, breakSentenceText);
         }
     }
 }

--- a/Detect.cs
+++ b/Detect.cs
@@ -33,7 +33,7 @@ namespace DetectSample
         // Async call to the Translator Text API
         static public async Task DetectTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            System.Object[] body = new System.Object[] { new { Text = inputText } };
+            object[] body = new object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())

--- a/Detect.cs
+++ b/Detect.cs
@@ -1,44 +1,84 @@
+// This sample requires C# 7.1 or later for async/await.
+
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+// Install Newtonsoft.Json with NuGet
 using Newtonsoft.Json;
 
-namespace DetectLanguage
+namespace DetectSample
 {
+    /// <summary>
+    /// The C# classes that represents the JSON returned by the Translator Text API.
+    /// </summary>
+    public class DetectResult
+    {
+        public string Language { get; set; }
+        public float Score { get; set; }
+        public bool IsTranslationSupported { get; set; }
+        public bool IsTransliterationSupported { get; set; }
+        public AltTranslations[] Alternatives { get; set; }
+    }
+    public class AltTranslations
+    {
+        public string Language { get; set; }
+        public float Score { get; set; }
+        public bool IsTranslationSupported { get; set; }
+        public bool IsTransliterationSupported { get; set; }
+    }
+
     class Program
     {
-        static void Detect()
+        // Async call to the Translator Text API
+        static public async Task DetectTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            string host = "https://api.cognitive.microsofttranslator.com";
-            string route = "/detect?api-version=3.0";
-            string subscriptionKey = "YOUR_SUBSCRIPTION_KEY";
-
-            System.Object[] body = new System.Object[] { new { Text = @"Salve mondo!" } };
+            System.Object[] body = new System.Object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())
             using (var request = new HttpRequestMessage())
             {
-                // Set the method to POST
+                // Build the request.
                 request.Method = HttpMethod.Post;
-                // Construct the full URI
                 request.RequestUri = new Uri(host + route);
-                // Add the serialized JSON object to your request
                 request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                // Add the authorization header
                 request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-                // Send request, get response
-                var response = client.SendAsync(request).Result;
-                var jsonResponse = response.Content.ReadAsStringAsync().Result;
-                // Print the response
-                Console.WriteLine(jsonResponse);
-                Console.WriteLine("Press any key to continue.");
+
+                // Send the request and get response.
+                HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
+                // Read response as a string.
+                string result = await response.Content.ReadAsStringAsync();
+                DetectResult[] deserializedOutput = JsonConvert.DeserializeObject<DetectResult[]>(result);
+                //Iterate through the response.
+                foreach (DetectResult o in deserializedOutput)
+                {
+                    Console.WriteLine("The detected language is '{0}'. Confidence is: {1}.\nTranslation supported: {2}.\nTransliteration supported: {3}.\n",
+                        o.Language, o.Score, o.IsTranslationSupported, o.IsTransliterationSupported);
+                    int counter = 0;
+                    // Iterate through alternatives. Use counter for alternative number.
+                    foreach (AltTranslations a in o.Alternatives)
+                    {
+                        counter++;
+                        Console.WriteLine("Alternative {0}", counter);
+                        Console.WriteLine("The detected language is '{0}'. Confidence is: {1}.\nTranslation supported: {2}.\nTransliteration supported: {3}.\n",
+                            a.Language, a.Score, a.IsTranslationSupported, a.IsTransliterationSupported);
+                    }
+                }
             }
         }
-        static void Main(string[] args)
+
+        static async Task Main(string[] args)
         {
-            Detect();
-            Console.ReadLine();
+            // This is our main function.
+            // Output languages are defined in the route.
+            // For a complete list of options, see API reference.
+            // https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-detect
+            string subscriptionKey = "YOUR_TRANSLATOR_TEXT_KEY_GOES_HERE";
+            string host = "https://api.cognitive.microsofttranslator.com";
+            string route = "/detect?api-version=3.0";
+            string breakSentenceText = @"How are you doing today? The weather is pretty pleasant. Have you been to the movies lately?";
+            await DetectTextRequest(subscriptionKey, host, route, breakSentenceText);
         }
     }
 }

--- a/Translate.cs
+++ b/Translate.cs
@@ -1,45 +1,107 @@
+// This sample requires C# 7.1 or later for async/await.
+
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+// Install Newtonsoft.Json with NuGet
 using Newtonsoft.Json;
 
-namespace TranslateText
+namespace TranslateTextSample
 {
+    /// <summary>
+    /// The C# classes that represents the JSON returned by the Translator Text API.
+    /// </summary>
+    public class TranslationResult
+    {
+        public DetectedLanguage DetectedLanguage { get; set; }
+        public TextResult SourceText { get; set; }
+        public Translation[] Translations { get; set; }
+    }
+
+    public class DetectedLanguage
+    {
+        public string Language { get; set; }
+        public float Score { get; set; }
+    }
+
+    public class TextResult
+    {
+        public string Text { get; set; }
+        public string Script { get; set; }
+    }
+
+    public class Translation
+    {
+        public string Text { get; set; }
+        public TextResult Transliteration { get; set; }
+        public string To { get; set; }
+        public Alignment Alignment { get; set; }
+        public SentenceLength SentLen { get; set; }
+    }
+
+    public class Alignment
+    {
+        public string Proj { get; set; }
+    }
+
+    public class SentenceLength
+    {
+        public int[] SrcSentLen { get; set; }
+        public int[] TransSentLen { get; set; }
+    }
+
     class Program
     {
-        static void TranslateText()
+        // Async call to the Translator Text API
+        static public async Task TranslateTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            string host = "https://api.cognitive.microsofttranslator.com";
-            string route = "/translate?api-version=3.0&to=de&to=it";
-            string subscriptionKey = "YOUR_SUBSCRIPTION_KEY";
-
-            System.Object[] body = new System.Object[] { new { Text = @"Hello world." } };
+            System.Object[] body = new System.Object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())
             using (var request = new HttpRequestMessage())
             {
-                // Set the method to POST
+                // Build the request.
                 request.Method = HttpMethod.Post;
-                // Construct the full URI
                 request.RequestUri = new Uri(host + route);
-                // Add the serialized JSON object to your request
                 request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                // Add the authorization header
                 request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-                // Send request, get response
-                var response = client.SendAsync(request).Result;
-                var jsonResponse = response.Content.ReadAsStringAsync().Result;
-                // Print the response
-                Console.WriteLine(jsonResponse);
-                Console.WriteLine("Press any key to continue.");
+
+                // Send the request and get response.
+                HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
+                // Read response as a string.
+                string result = await response.Content.ReadAsStringAsync();
+                TranslationResult[] deserializedOutput = JsonConvert.DeserializeObject<TranslationResult[]>(result);
+                // Iterate over the deserialized results.
+                foreach (TranslationResult o in deserializedOutput)
+                {
+                    // Print the detected input languge and confidence score.
+                    Console.WriteLine("Detected input language: {0}\nConfidence score: {1}\n", o.DetectedLanguage.Language, o.DetectedLanguage.Score);
+                    // Iterate over the results and print each translation.
+                    foreach (Translation t in o.Translations)
+                    {
+                        Console.WriteLine("Translated to {0}: {1}", t.To, t.Text);
+                    }
+                }
             }
         }
-        static void Main(string[] args)
-        {
-            TranslateText();
-            Console.ReadLine();
 
+        static async Task Main(string[] args)
+        {
+            // This is our main function.
+            // Output languages are defined in the route.
+            // For a complete list of options, see API reference.
+            // https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-translate
+            string host = "https://api.cognitive.microsofttranslator.com";
+            string route = "/translate?api-version=3.0&to=de&to=it&to=ja&to=th";
+            string subscriptionKey = "YOUR_TRANSLATOR_TEXT_KEY_GOES_HERE";
+            // Prompts you for text to translate. If you'd prefer, you can
+            // provide a string as textToTranslate.
+            Console.Write("Type the phrase you'd like to translate? ");
+            string textToTranslate = Console.ReadLine();
+            await TranslateTextRequest(subscriptionKey, host, route, textToTranslate);
         }
     }
 }

--- a/Translate.cs
+++ b/Translate.cs
@@ -57,7 +57,7 @@ namespace TranslateTextSample
         // Async call to the Translator Text API
         static public async Task TranslateTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            System.Object[] body = new System.Object[] { new { Text = inputText } };
+            object[] body = new object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())

--- a/Transliterate.cs
+++ b/Transliterate.cs
@@ -1,44 +1,64 @@
+// This sample requires C# 7.1 or later for async/await.
+
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+// Install Newtonsoft.Json with NuGet
 using Newtonsoft.Json;
 
-namespace TransliterateText
+namespace TransliterateTextSample
 {
+    /// <summary>
+    /// The C# classes that represents the JSON returned by the Translator Text API.
+    /// </summary>
+    public class TransliterationResult
+    {
+        public string Text { get; set; }
+        public string Script { get; set; }
+    }
+
     class Program
     {
-        static void TransliterateText()
+        // Async call to the Translator Text API
+        static public async Task TransliterateTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            string host = "https://api.cognitive.microsofttranslator.com";
-            string route = "/transliterate?api-version=3.0&language=ja&fromScript=jpan&toScript=latn";
-            string subscriptionKey = "YOUR_SUBSCRIPTION_KEY";
-
-            System.Object[] body = new System.Object[] { new { Text = @"こんにちは" } };
+            System.Object[] body = new System.Object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())
             using (var request = new HttpRequestMessage())
             {
-                // Set the method to POST
+                // Build the request.
                 request.Method = HttpMethod.Post;
-                // Construct the full URI
                 request.RequestUri = new Uri(host + route);
-                // Add the serialized JSON object to your request
                 request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                // Add the authorization header
                 request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-                // Send request, get response
-                var response = client.SendAsync(request).Result;
-                var jsonResponse = response.Content.ReadAsStringAsync().Result;
-                // Print the response
-                Console.WriteLine(jsonResponse);
-                Console.WriteLine("Press any key to continue.");
+
+                // Send the request and get response.
+                HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);
+                // Read response as a string.
+                string result = await response.Content.ReadAsStringAsync();
+                TransliterationResult[] deserializedOutput = JsonConvert.DeserializeObject<TransliterationResult[]>(result);
+                // Iterate over the deserialized results.
+                foreach (TransliterationResult o in deserializedOutput)
+                {
+                       Console.WriteLine("Transliterated to {0} script: {1}", o.Script, o.Text);
+                }
             }
         }
-        static void Main(string[] args)
+
+        static async Task Main(string[] args)
         {
-            TransliterateText();
-            Console.ReadLine();
+            // This is our main function.
+            // Output languages are defined in the route.
+            // For a complete list of options, see API reference.
+            // https://docs.microsoft.com/azure/cognitive-services/translator/reference/v3-0-transliterate
+            string subscriptionKey = "YOUR_TRANSLATOR_TEXT_KEY_GOES_HERE";
+            string host = "https://api.cognitive.microsofttranslator.com";
+            string route = "/transliterate?api-version=3.0&language=ja&fromScript=jpan&toScript=latn";
+            string textToTransliterate = @"こんにちは";
+            await TransliterateTextRequest(subscriptionKey, host, route, textToTransliterate);
         }
     }
 }

--- a/Transliterate.cs
+++ b/Transliterate.cs
@@ -23,7 +23,7 @@ namespace TransliterateTextSample
         // Async call to the Translator Text API
         static public async Task TransliterateTextRequest(string subscriptionKey, string host, string route, string inputText)
         {
-            System.Object[] body = new System.Object[] { new { Text = inputText } };
+            object[] body = new object[] { new { Text = inputText } };
             var requestBody = JsonConvert.SerializeObject(body);
 
             using (var client = new HttpClient())


### PR DESCRIPTION
The samples for `Translate.cs`, `Transliterate.cs`, `Detect.cs`, and `BreakSentence.cs` have been updated to use C# classes for deserialized JSON responses. This addresses: https://github.com/MicrosoftDocs/azure-docs/issues/22176. 

Still open: 
* `DictionaryExamples.cs`
* `DictionaryLookup.cs`