### PR TITLE
Update .NET SDK link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository includes .NET Core samples for Microsoft Translator. Each sample
 
 Here's what you'll need before you use these samples:
 
-* [.NET SDK](https://dotnet.microsoft.com/download)
+* [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download)
 * [Json.NET NuGet Package](https://www.nuget.org/packages/Newtonsoft.Json/)
 * [Visual Studio](https://visualstudio.microsoft.com/downloads/), [Visual Studio Code](https://code.visualstudio.com/download), or your favorite text editor
 * An Azure subscription - [Sign-up for a free account](https://docs.microsoft.com/azure/cognitive-services/translator/translator-text-how-to-signup)!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository includes .NET Core samples for Microsoft Translator. Each sample
 
 Here's what you'll need before you use these samples:
 
-* [.NET SDK](https://www.microsoft.com/net/learn/dotnet/hello-world-tutorial)
+* [.NET SDK](https://dotnet.microsoft.com/download)
 * [Json.NET NuGet Package](https://www.nuget.org/packages/Newtonsoft.Json/)
 * [Visual Studio](https://visualstudio.microsoft.com/downloads/), [Visual Studio Code](https://code.visualstudio.com/download), or your favorite text editor
 * An Azure subscription - [Sign-up for a free account](https://docs.microsoft.com/azure/cognitive-services/translator/translator-text-how-to-signup)!


### PR DESCRIPTION
We got feedback on the dot.net website from customers using these samples that the link used here was not helpful.

It would also be useful to tell them which version to download - not exactly sure against which version these samples were tested.

Here's the full feedback we got for https://www.microsoft.com/net/learn/dotnet/hello-world-tutorial:
"Wrong page.   This is supposed to be the download of the .NET SDK ; liked from Microsoft's GitHub Cognitive Service, Translation sample as a prerequisite:  https://docs.microsoft.com/en-us/samples/microsofttranslator/text-translation-api-v3-c-sharp/translator-c-sharp-v3/  That a page for some other, mostly unrelated, sample opens is extremely confusing. What I needed to know is what specific version and flavor of .NET is the required prerequisite as .NET Core, .NET 5, and all other variants of WinRT are entirely unusable. .NET Framework 4.6 - 4.8, remain the only stable and usable .NET for Windows."